### PR TITLE
Update GeoJSON.js

### DIFF
--- a/src/GeoJSON.js
+++ b/src/GeoJSON.js
@@ -197,6 +197,10 @@ var GeoJSON = (function() {
         geometries,
         baseItem, item;
 
+      if (collection == undefined)
+      {	return[]; }
+
+
       for (i = 0, il = collection.length; i < il; i++) {
         feature = collection[i];
 


### PR DESCRIPTION
geojson.features can become undefined because of the way that Postgresql builds it json strings in the query. This change prevents an error by simply ignoring the collection if it is undefined.